### PR TITLE
Fixed typo in Coding Obfuscation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,7 +753,7 @@ Unfortunately, these techniques can only be used in native C classes, not Java.
 
 #### L o n g   L i n e s
 
-Try to pack as much as possible into a single line. This saves the overhead of temporary variables, and makes source files shorter by eliminating new line characters and white space. Tipremove all white space around operators. Good programmers can often hit the 255 character line length limit imposed by some editors. The bonus of long lines is that programmers who cannot read 6 point type must scroll to view them.
+Try to pack as much as possible into a single line. This saves the overhead of temporary variables, and makes source files shorter by eliminating new line characters and white space. Tip: remove all white space around operators. Good programmers can often hit the 255 character line length limit imposed by some editors. The bonus of long lines is that programmers who cannot read 6 point type must scroll to view them.
 
 #### Exceptions
 


### PR DESCRIPTION
Tip: Remove was originally concatenated as tipremove.
