### PR TITLE
Fix apparent markdown formatting mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,7 +851,7 @@ if ( function_A() == OK )
 
 #### Pseudo C
 
-The real reason for `#define` was to help programmers who are familiar with another programming language to switch to C. Maybe you will find declarations like `#define begin { " or " #define end }` useful to write more interesting code.
+The real reason for `#define` was to help programmers who are familiar with another programming language to switch to C. Maybe you will find declarations like `#define begin {` or `#define end }` useful to write more interesting code.
 
 #### Confounding Imports
 


### PR DESCRIPTION
This seems like an obvious fix to an obvious mistake, but the same
"mistake" also appears in the upstream source material at
http://mindprod.com/jgloss/unmainobfuscation.html.
I suspect it was introduced during an earlier format conversion and was
just never fixed.
