### PR TITLE
markdown escape fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ break up `xy_z` onto two lines:
 _z // local_var OK
 ```
 
-That way a global search for `xy_z` will come up with nothing for that file. To the C preprocessor, the "\" at the end of the line means glue this line to the next one.
+That way a global search for `xy_z` will come up with nothing for that file. To the C preprocessor, the `\` at the end of the line means glue this line to the next one.
 
 #### Arbitrary Names That Masquerade as Keywords
 


### PR DESCRIPTION
`"\"` displays as `""` in markdown. Fix this by changing double quotes to backticks.