### PR TITLE
Fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1213,7 +1213,7 @@ Have the makefile-generated-batch-file copy source files from multiple directori
 
 #### Collect Coding Standards
 
-Find all the tips you can on writing maintainable code such as the [Square Box Suggestions](http://www.squarebox.co.uk/javatips.html) and flagrantly violate them.
+Find all the tips you can on writing maintainable code such as the [Square Box Suggestions](http://www.squarebox.co.uk/download/javatips.html) and flagrantly violate them.
 
 #### IDE, Not Me!
 


### PR DESCRIPTION
The link to the "Square Box Suggestions" got moved some time in 2005. It used to have a redirect, but the redirect gives you a 404 now, even though the page is still there. I went ahead and found the page's current location and updated the text to reflect that.